### PR TITLE
QOL changes

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -8,5 +8,8 @@
 	<classpathentry kind="var" path="wpiutil" sourcepath="wpiutil.sources"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="var" path="navx-mxp"/>
+	<classpathentry kind="var" path="USERLIBS_DIR/CTRE_Phoenix-sources.jar"/>
+	<classpathentry kind="var" path="USERLIBS_DIR/CTRE_Phoenix.jar"/>
+	<classpathentry kind="var" path="USERLIBS_DIR/navx_frc.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -10,6 +10,8 @@
 	<classpathentry kind="var" path="navx-mxp"/>
 	<classpathentry kind="var" path="USERLIBS_DIR/CTRE_Phoenix-sources.jar"/>
 	<classpathentry kind="var" path="USERLIBS_DIR/CTRE_Phoenix.jar"/>
+	<classpathentry kind="var" path="USERLIBS_DIR/CTRE_Phoenix_WPIAPI-sources.jar"/>
+	<classpathentry kind="var" path="USERLIBS_DIR/CTRE_Phoenix_WPIAPI.jar"/>
 	<classpathentry kind="var" path="USERLIBS_DIR/navx_frc.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/src/org/usfirst/frc/team1922/robot/OI.java
+++ b/src/org/usfirst/frc/team1922/robot/OI.java
@@ -7,15 +7,19 @@
 
 package org.usfirst.frc.team1922.robot;
 
-import org.usfirst.frc.team1922.robot.commands.*;
 //import org.usfirst.frc.team1922.robot.extras.LimitSwitch;
+import org.usfirst.frc.team1922.robot.commands.DeployElevator_Command;
+import org.usfirst.frc.team1922.robot.commands.Deposit_Command;
+import org.usfirst.frc.team1922.robot.commands.ElevateToScale_Command;
+import org.usfirst.frc.team1922.robot.commands.ElevatorDown_Command;
+import org.usfirst.frc.team1922.robot.commands.ElevatorUp_Command;
 
 import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.XboxController;
 //import edu.wpi.first.wpilibj.Solenoid;
 //import edu.wpi.first.wpilibj.Joystick.ButtonType;
 import edu.wpi.first.wpilibj.buttons.Button;
-import edu.wpi.first.wpilibj.buttons.JoystickButton;
-import edu.wpi.first.wpilibj.XboxController; 
+import edu.wpi.first.wpilibj.buttons.JoystickButton; 
 
 
 /**

--- a/src/org/usfirst/frc/team1922/robot/OI.java
+++ b/src/org/usfirst/frc/team1922/robot/OI.java
@@ -27,7 +27,6 @@ public class OI {
 	private Joystick m_leftStick;
 	private Joystick m_rightStick;
 	private XboxController m_operator;
-	//private Joystick m_operator;
 	private Button leftTrigger;
 //	private Button rightTrigger;
 	private Button operatorFirst;
@@ -44,7 +43,6 @@ public class OI {
 		m_leftStick = new Joystick(1); 
 		m_rightStick = new Joystick(0);
 		m_operator = new XboxController(2);
-		//m_operator = new Joystick(2); //Previously the third joystick used in 2017
 		leftTrigger = new JoystickButton(getLeftStick(), 1); 
 //		rightTrigger = new JoystickButton(getRightStick(), 1); 
 		operatorFirst = new JoystickButton(getOperator(), 1); 

--- a/src/org/usfirst/frc/team1922/robot/Robot.java
+++ b/src/org/usfirst/frc/team1922/robot/Robot.java
@@ -7,15 +7,22 @@
 
 package org.usfirst.frc.team1922.robot;
 
+import org.usfirst.frc.team1922.robot.commands.autogroups.Center;
+import org.usfirst.frc.team1922.robot.commands.autogroups.CrossAutoLine;
+import org.usfirst.frc.team1922.robot.commands.autogroups.Left;
+import org.usfirst.frc.team1922.robot.commands.autogroups.Right;
+import org.usfirst.frc.team1922.robot.commands.autogroups.Test;
+import org.usfirst.frc.team1922.robot.subsystems.DriveTrain_Subsystem;
+import org.usfirst.frc.team1922.robot.subsystems.Elevator_Subsystem;
+import org.usfirst.frc.team1922.robot.subsystems.Intake_Subsystem;
+
 //import edu.wpi.first.wpilibj.CameraServer; //Used for drive camera
-import edu.wpi.first.wpilibj.DriverStation; 
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.command.Scheduler;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import org.usfirst.frc.team1922.robot.commands.autogroups.*;
-import org.usfirst.frc.team1922.robot.subsystems.*;
 
 public class Robot extends TimedRobot {
 	public static DriveTrain_Subsystem m_driveTrain; 

--- a/src/org/usfirst/frc/team1922/robot/commands/DeployElevator_Command.java
+++ b/src/org/usfirst/frc/team1922/robot/commands/DeployElevator_Command.java
@@ -1,6 +1,7 @@
 package org.usfirst.frc.team1922.robot.commands;
 
 import org.usfirst.frc.team1922.robot.Robot;
+
 //import org.usfirst.frc.team1922.robot.subsystems.Elevator_Subsystem;
 import edu.wpi.first.wpilibj.command.Command;
 

--- a/src/org/usfirst/frc/team1922/robot/commands/ElevatorUp_Command.java
+++ b/src/org/usfirst/frc/team1922/robot/commands/ElevatorUp_Command.java
@@ -1,6 +1,7 @@
 package org.usfirst.frc.team1922.robot.commands;
 
 import org.usfirst.frc.team1922.robot.Robot;
+
 import edu.wpi.first.wpilibj.command.Command;
 
 public class ElevatorUp_Command extends Command {

--- a/src/org/usfirst/frc/team1922/robot/commands/TurnTo_Command.java
+++ b/src/org/usfirst/frc/team1922/robot/commands/TurnTo_Command.java
@@ -1,5 +1,7 @@
 package org.usfirst.frc.team1922.robot.commands;
+
 import org.usfirst.frc.team1922.robot.Robot;
+
 import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 

--- a/src/org/usfirst/frc/team1922/robot/commands/ZeroDrive_Command.java
+++ b/src/org/usfirst/frc/team1922/robot/commands/ZeroDrive_Command.java
@@ -1,4 +1,5 @@
 package org.usfirst.frc.team1922.robot.commands;
+
 import org.usfirst.frc.team1922.robot.Robot;
 
 import edu.wpi.first.wpilibj.command.Command;

--- a/src/org/usfirst/frc/team1922/robot/commands/autogroups/Center.java
+++ b/src/org/usfirst/frc/team1922/robot/commands/autogroups/Center.java
@@ -5,7 +5,6 @@ import org.usfirst.frc.team1922.robot.RobotMap;
 import org.usfirst.frc.team1922.robot.commands.DeployElevator_Command;
 import org.usfirst.frc.team1922.robot.commands.Deposit_Command;
 import org.usfirst.frc.team1922.robot.commands.DriveStraight_Command;
-//import org.usfirst.frc.team1922.robot.commands.DriveStraight_Command;
 import org.usfirst.frc.team1922.robot.commands.DriveTo_Command;
 import org.usfirst.frc.team1922.robot.commands.ElevateToScale_Command;
 import org.usfirst.frc.team1922.robot.commands.ElevateToSwitch_Command;
@@ -50,12 +49,6 @@ public class Center extends CommandGroup{
 			
 			addSequential( new Deposit_Command());
 			
-			
-			
-			
-			
-			
-			
 //			addSequential( new ZeroDrive_Command());
 //			addSequential (new Wait(.2));
 //			addSequential( new DriveStraight_Command(1)); 
@@ -91,7 +84,7 @@ public class Center extends CommandGroup{
 //			
 //			addSequential( new ZeroDrive_Command());
 //			addSequential( new Wait(.2));
-//			
+
 			addSequential( new DriveStraight_Command(7.67 - RobotMap.BotLength));
 			addParallel( new ElevateToSwitch_Command());
 			addSequential( new Wait(.2));

--- a/src/org/usfirst/frc/team1922/robot/commands/autogroups/Center.java
+++ b/src/org/usfirst/frc/team1922/robot/commands/autogroups/Center.java
@@ -6,7 +6,6 @@ import org.usfirst.frc.team1922.robot.commands.DeployElevator_Command;
 import org.usfirst.frc.team1922.robot.commands.Deposit_Command;
 import org.usfirst.frc.team1922.robot.commands.DriveStraight_Command;
 import org.usfirst.frc.team1922.robot.commands.DriveTo_Command;
-import org.usfirst.frc.team1922.robot.commands.ElevateToScale_Command;
 import org.usfirst.frc.team1922.robot.commands.ElevateToSwitch_Command;
 import org.usfirst.frc.team1922.robot.commands.TurnTo_Command;
 import org.usfirst.frc.team1922.robot.commands.Wait;
@@ -44,7 +43,7 @@ public class Center extends CommandGroup{
 			addSequential (new Wait(.5));
 			
 			addSequential( new DriveStraight_Command(8.6 - RobotMap.BotLength));
-			addParallel(new ElevateToScale_Command());
+			addParallel(new ElevateToSwitch_Command());
 			addSequential( new Wait(.2));
 			
 			addSequential( new Deposit_Command());

--- a/src/org/usfirst/frc/team1922/robot/commands/autogroups/Center.java
+++ b/src/org/usfirst/frc/team1922/robot/commands/autogroups/Center.java
@@ -34,7 +34,7 @@ public class Center extends CommandGroup{
 			addSequential( new ZeroDrive_Command());
 			addSequential (new Wait(.5));
 			
-			addSequential( new DriveStraight_Command(8.8 - RobotMap.BotLength));
+			addSequential( new DriveStraight_Command(10.0 - RobotMap.BotLength));
 			addSequential( new Wait(.2));
 			addSequential( new ZeroDrive_Command());
 			addSequential (new Wait(.5));
@@ -47,6 +47,7 @@ public class Center extends CommandGroup{
 			addSequential( new DriveStraight_Command(8.6 - RobotMap.BotLength));
 			addParallel(new ElevateToScale_Command());
 			addSequential( new Wait(.2));
+			
 			addSequential( new Deposit_Command());
 			
 			

--- a/src/org/usfirst/frc/team1922/robot/commands/autogroups/CrossAutoLine.java
+++ b/src/org/usfirst/frc/team1922/robot/commands/autogroups/CrossAutoLine.java
@@ -1,7 +1,8 @@
 package org.usfirst.frc.team1922.robot.commands.autogroups;
 
 import org.usfirst.frc.team1922.robot.commands.DeployElevator_Command;
-import org.usfirst.frc.team1922.robot.commands.DriveTo_Command;
+import org.usfirst.frc.team1922.robot.commands.DriveStraight_Command;
+//import org.usfirst.frc.team1922.robot.commands.DriveTo_Command;
 import org.usfirst.frc.team1922.robot.commands.Wait;
 import org.usfirst.frc.team1922.robot.commands.ZeroDrive_Command;
 
@@ -13,7 +14,6 @@ public class CrossAutoLine extends CommandGroup{
 		addSequential( new ZeroDrive_Command());
 		addSequential( new Wait(.25));
 		addParallel( new DeployElevator_Command());
-		addSequential( new DriveTo_Command(0, 11));
-		//addSequential( new DriveStraight_Command(6));
+		addSequential( new DriveStraight_Command(11));
 	}
 }

--- a/src/org/usfirst/frc/team1922/robot/commands/autogroups/Left.java
+++ b/src/org/usfirst/frc/team1922/robot/commands/autogroups/Left.java
@@ -5,8 +5,6 @@ import org.usfirst.frc.team1922.robot.RobotMap;
 import org.usfirst.frc.team1922.robot.commands.DeployElevator_Command;
 import org.usfirst.frc.team1922.robot.commands.Deposit_Command;
 import org.usfirst.frc.team1922.robot.commands.DriveStraight_Command;
-//import org.usfirst.frc.team1922.robot.commands.DriveTo_Command;
-import org.usfirst.frc.team1922.robot.commands.ElevateToScale_Command;
 import org.usfirst.frc.team1922.robot.commands.ElevateToSwitch_Command;
 import org.usfirst.frc.team1922.robot.commands.TurnTo_Command;
 import org.usfirst.frc.team1922.robot.commands.Wait;
@@ -40,26 +38,26 @@ public class Left extends CommandGroup{
 			
 			addSequential( new Deposit_Command());	
 		}
-		else if(Robot.getPositions().substring(1,2).equals("L")){
-				addSequential( new ZeroDrive_Command());
-				addSequential( new Wait(.1));
-				addSequential( new DeployElevator_Command());
-				addSequential( new Wait(.5));
-				
-				addSequential( new DriveStraight_Command (27 - RobotMap.BotLength)); //22
-				addSequential( new Wait(.2));
-				
-				
-				addSequential( new ZeroDrive_Command());
-				addSequential( new Wait(.5));
-				addSequential( new TurnTo_Command(90));
-				addSequential( new Wait(.2));
-				addSequential( new ElevateToScale_Command());
-				addSequential( new Wait(.5));
-
-				
-				addSequential( new Deposit_Command());
-		} 
+//		else if(Robot.getPositions().substring(1,2).equals("L")){
+//				addSequential( new ZeroDrive_Command());
+//				addSequential( new Wait(.1));
+//				addSequential( new DeployElevator_Command());
+//				addSequential( new Wait(.5));
+//				
+//				addSequential( new DriveStraight_Command (27 - RobotMap.BotLength)); //22
+//				addSequential( new Wait(.2));
+//				
+//				
+//				addSequential( new ZeroDrive_Command());
+//				addSequential( new Wait(.5));
+//				addSequential( new TurnTo_Command(90));
+//				addSequential( new Wait(.2));
+//				addSequential( new ElevateToScale_Command());
+//				addSequential( new Wait(.5));
+//
+//				
+//				addSequential( new Deposit_Command());
+//		} 
 		else {
 			addParallel( new DeployElevator_Command());
 			addSequential( new DriveStraight_Command(11));

--- a/src/org/usfirst/frc/team1922/robot/commands/autogroups/Left.java
+++ b/src/org/usfirst/frc/team1922/robot/commands/autogroups/Left.java
@@ -25,14 +25,13 @@ public class Left extends CommandGroup{
 			addParallel( new ElevateToSwitch_Command());
 			addSequential( new Wait(.5)); 
 			
-			addSequential (new DriveStraight_Command (13.75- (RobotMap.BotLength/2)));
+			addSequential( new DriveStraight_Command(13.75 - (RobotMap.BotLength/2)));
 			//addSequential( new DriveTo_Command(0, 11 - RobotMap.BotLength)); 
 			addSequential( new Wait(.2));
 			
-			
 			addSequential( new ZeroDrive_Command());
 			addSequential( new Wait(.5));
-			addSequential(new TurnTo_Command(90));
+			addSequential( new TurnTo_Command(90));
 			
 			addSequential( new Wait(.2));
 			

--- a/src/org/usfirst/frc/team1922/robot/commands/autogroups/Left.java
+++ b/src/org/usfirst/frc/team1922/robot/commands/autogroups/Left.java
@@ -5,7 +5,7 @@ import org.usfirst.frc.team1922.robot.RobotMap;
 import org.usfirst.frc.team1922.robot.commands.DeployElevator_Command;
 import org.usfirst.frc.team1922.robot.commands.Deposit_Command;
 import org.usfirst.frc.team1922.robot.commands.DriveStraight_Command;
-import org.usfirst.frc.team1922.robot.commands.DriveTo_Command;
+//import org.usfirst.frc.team1922.robot.commands.DriveTo_Command;
 import org.usfirst.frc.team1922.robot.commands.ElevateToScale_Command;
 import org.usfirst.frc.team1922.robot.commands.ElevateToSwitch_Command;
 import org.usfirst.frc.team1922.robot.commands.TurnTo_Command;

--- a/src/org/usfirst/frc/team1922/robot/commands/autogroups/Right.java
+++ b/src/org/usfirst/frc/team1922/robot/commands/autogroups/Right.java
@@ -5,8 +5,6 @@ import org.usfirst.frc.team1922.robot.RobotMap;
 import org.usfirst.frc.team1922.robot.commands.DeployElevator_Command;
 import org.usfirst.frc.team1922.robot.commands.Deposit_Command;
 import org.usfirst.frc.team1922.robot.commands.DriveStraight_Command;
-//import org.usfirst.frc.team1922.robot.commands.DriveTo_Command;
-import org.usfirst.frc.team1922.robot.commands.ElevateToScale_Command;
 import org.usfirst.frc.team1922.robot.commands.ElevateToSwitch_Command;
 import org.usfirst.frc.team1922.robot.commands.TurnTo_Command;
 import org.usfirst.frc.team1922.robot.commands.Wait;
@@ -38,25 +36,25 @@ public class Right extends CommandGroup{
 			
 			addSequential( new Deposit_Command());	
 		}
-		else if(Robot.getPositions().substring(1,2).equals("R")){
-				addSequential( new ZeroDrive_Command());
-				addSequential( new Wait(.1));
-				addSequential( new DeployElevator_Command());
-				addSequential( new Wait(.5));
-				
-				addSequential( new DriveStraight_Command(27 - RobotMap.BotLength)); //22
-				addSequential( new Wait(.2));
-				
-				
-				addSequential( new ZeroDrive_Command());
-				addSequential( new Wait(.5));
-				addSequential( new TurnTo_Command(-90));
-				
-				addSequential( new Wait(.2));
-				addSequential( new ElevateToScale_Command());
-				addSequential( new Wait(.5));
-				addSequential( new Deposit_Command());
-		} 
+//		else if(Robot.getPositions().substring(1,2).equals("R")){
+//				addSequential( new ZeroDrive_Command());
+//				addSequential( new Wait(.1));
+//				addSequential( new DeployElevator_Command());
+//				addSequential( new Wait(.5));
+//				
+//				addSequential( new DriveStraight_Command(27 - RobotMap.BotLength)); //22
+//				addSequential( new Wait(.2));
+//				
+//				
+//				addSequential( new ZeroDrive_Command());
+//				addSequential( new Wait(.5));
+//				addSequential( new TurnTo_Command(-90));
+//				
+//				addSequential( new Wait(.2));
+//				addSequential( new ElevateToScale_Command());
+//				addSequential( new Wait(.5));
+//				addSequential( new Deposit_Command());
+//		} 
 		else {
 			addParallel( new DeployElevator_Command());
 			addSequential( new DriveStraight_Command(11));

--- a/src/org/usfirst/frc/team1922/robot/commands/autogroups/Right.java
+++ b/src/org/usfirst/frc/team1922/robot/commands/autogroups/Right.java
@@ -5,7 +5,7 @@ import org.usfirst.frc.team1922.robot.RobotMap;
 import org.usfirst.frc.team1922.robot.commands.DeployElevator_Command;
 import org.usfirst.frc.team1922.robot.commands.Deposit_Command;
 import org.usfirst.frc.team1922.robot.commands.DriveStraight_Command;
-import org.usfirst.frc.team1922.robot.commands.DriveTo_Command;
+//import org.usfirst.frc.team1922.robot.commands.DriveTo_Command;
 import org.usfirst.frc.team1922.robot.commands.ElevateToScale_Command;
 import org.usfirst.frc.team1922.robot.commands.ElevateToSwitch_Command;
 import org.usfirst.frc.team1922.robot.commands.TurnTo_Command;
@@ -59,7 +59,7 @@ public class Right extends CommandGroup{
 		} 
 		else {
 			addParallel( new DeployElevator_Command());
-			addSequential( new DriveTo_Command(0, 11));
+			addSequential( new DriveStraight_Command(11));
 		}
 	}
 	

--- a/src/org/usfirst/frc/team1922/robot/commands/autogroups/Right.java
+++ b/src/org/usfirst/frc/team1922/robot/commands/autogroups/Right.java
@@ -15,6 +15,7 @@ import edu.wpi.first.wpilibj.command.CommandGroup;
 public class Right extends CommandGroup{
 	
 	public Right() {
+		
 		if(Robot.getPositions().substring(0,1).equals("R")) {
 			
 			addSequential( new ZeroDrive_Command());

--- a/src/org/usfirst/frc/team1922/robot/commands/autogroups/Test.java
+++ b/src/org/usfirst/frc/team1922/robot/commands/autogroups/Test.java
@@ -1,10 +1,10 @@
 package org.usfirst.frc.team1922.robot.commands.autogroups;
 
 import org.usfirst.frc.team1922.robot.commands.DeployElevator_Command;
-import org.usfirst.frc.team1922.robot.commands.DriveStraight_Command;
-import org.usfirst.frc.team1922.robot.commands.DriveTo_Command;
-import org.usfirst.frc.team1922.robot.commands.TurnTo_Command;
-import org.usfirst.frc.team1922.robot.commands.Turn_Command;
+//import org.usfirst.frc.team1922.robot.commands.DriveStraight_Command;
+//import org.usfirst.frc.team1922.robot.commands.DriveTo_Command;
+//import org.usfirst.frc.team1922.robot.commands.TurnTo_Command;
+//import org.usfirst.frc.team1922.robot.commands.Turn_Command;
 import org.usfirst.frc.team1922.robot.commands.Wait;
 import org.usfirst.frc.team1922.robot.commands.ZeroDrive_Command;
 

--- a/src/org/usfirst/frc/team1922/robot/subsystems/DriveTrain_Subsystem.java
+++ b/src/org/usfirst/frc/team1922/robot/subsystems/DriveTrain_Subsystem.java
@@ -2,7 +2,6 @@ package org.usfirst.frc.team1922.robot.subsystems;
 
 import org.usfirst.frc.team1922.robot.RobotMap;
 import org.usfirst.frc.team1922.robot.commands.TankDrive_Command;
-import edu.wpi.first.wpilibj.SPI;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.ctre.phoenix.motorcontrol.FeedbackDevice;
@@ -10,6 +9,7 @@ import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 import com.kauailabs.navx.frc.AHRS;
 
 import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.SPI;
 import edu.wpi.first.wpilibj.Solenoid;
 import edu.wpi.first.wpilibj.command.Subsystem;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;

--- a/src/org/usfirst/frc/team1922/robot/subsystems/Intake_Subsystem.java
+++ b/src/org/usfirst/frc/team1922/robot/subsystems/Intake_Subsystem.java
@@ -5,9 +5,9 @@ import org.usfirst.frc.team1922.robot.commands.OperateIntake_Command;
 
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 
+import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.command.Subsystem;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj.XboxController; 
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard; 
 
 public class Intake_Subsystem extends Subsystem{
 


### PR DESCRIPTION
Mostly reorganizing imports through Eclipse, but has a required update to the classpath that causes Eclipse to ignore the CTRE Pheonix plugins. Will work on uncommenting the left and right scale autos once we get time to debug. 